### PR TITLE
Fix customer address visualization and scrolling

### DIFF
--- a/frontend/src/pages/CustomerDetail.css
+++ b/frontend/src/pages/CustomerDetail.css
@@ -376,6 +376,9 @@
   justify-content: center;
   z-index: 1000;
   animation: fadeIn 0.2s ease;
+  overflow-y: auto; /* Allow overlay to scroll */
+  padding: 20px; /* Add padding for mobile */
+  touch-action: none; /* Prevent touch scrolling on the overlay */
 }
 
 .modal-content {
@@ -383,10 +386,15 @@
   border-radius: 12px;
   width: 90%;
   max-width: 800px;
-  max-height: 90vh;
-  overflow: auto;
+  max-height: calc(100vh - 40px); /* Account for padding */
+  overflow-y: auto; /* Enable vertical scrolling */
+  overflow-x: hidden; /* Hide horizontal scrollbar */
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
   animation: slideUp 0.3s ease;
+  margin: auto; /* Center in the available space */
+  position: relative; /* Ensure proper positioning */
+  touch-action: pan-y; /* Allow vertical touch scrolling */
+  -webkit-overflow-scrolling: touch; /* Smooth scrolling on iOS */
 }
 
 .modal-header {
@@ -426,6 +434,9 @@
 /* Address Form */
 .address-form {
   padding: 24px;
+  max-height: calc(90vh - 100px); /* Account for modal header */
+  overflow-y: auto; /* Enable scrolling within form */
+  overflow-x: hidden;
 }
 
 .form-grid {

--- a/frontend/src/pages/CustomerDetail.js
+++ b/frontend/src/pages/CustomerDetail.js
@@ -51,6 +51,28 @@ const CustomerDetail = () => {
     fetchCustomerAddresses();
   }, [customerId]);
 
+  // Prevent body scrolling when modal is open
+  useEffect(() => {
+    if (showAddressForm) {
+      // Save current scroll position
+      const scrollY = window.scrollY;
+      document.body.style.position = 'fixed';
+      document.body.style.top = `-${scrollY}px`;
+      document.body.style.width = '100%';
+      document.body.style.overflow = 'hidden';
+      
+      return () => {
+        // Restore scroll position when modal closes
+        const scrollY = document.body.style.top;
+        document.body.style.position = '';
+        document.body.style.top = '';
+        document.body.style.width = '';
+        document.body.style.overflow = '';
+        window.scrollTo(0, parseInt(scrollY || '0') * -1);
+      };
+    }
+  }, [showAddressForm]);
+
   const fetchCustomerDetails = async () => {
     try {
       const result = await customerService.getCustomerById(customerId);
@@ -222,10 +244,8 @@ const CustomerDetail = () => {
         tenant_id: tenantId,
         created_by: currentUser.id,
         is_default: false, // Always set to false since we removed the checkbox
-        // Format coordinates as PostgreSQL POINT if they exist
-        coordinates: addressForm.coordinates ? 
-          `POINT(${addressForm.coordinates[0]} ${addressForm.coordinates[1]})` : 
-          null
+        // Send coordinates as array - backend will convert to POINT format
+        coordinates: addressForm.coordinates || null
       };
       
       // Final validation - ensure no required fields are missing
@@ -310,10 +330,8 @@ const CustomerDetail = () => {
       const addressData = {
         ...addressForm,
         is_default: editingAddress.is_default, // Keep the existing default status when updating
-        // Format coordinates as PostgreSQL POINT if they exist
-        coordinates: addressForm.coordinates ? 
-          `POINT(${addressForm.coordinates[0]} ${addressForm.coordinates[1]})` : 
-          null
+        // Send coordinates as array - backend will convert to POINT format
+        coordinates: addressForm.coordinates || null
       };
       
       // Debug: Log the address data being sent


### PR DESCRIPTION
Fix map visualization for saved addresses and enable scrolling in the Add New Address modal.

The map visualization issue stemmed from the frontend double-converting coordinates to WKT POINT format before sending them to the backend, which already handles conversion from `[lng, lat]` arrays. This resulted in malformed data. The modal scrolling issue was due to CSS conflicts preventing the modal content from scrolling, instead scrolling the background page.

---

[Open in Web](https://cursor.com/agents?id=bc-0b7a410e-4d3a-40ff-aa13-f38ad4a4ac3d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-0b7a410e-4d3a-40ff-aa13-f38ad4a4ac3d)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid or empty coordinate inputs in the address map, with clearer error messages and better support for various coordinate formats.
  * Enhanced modal scrolling behavior and touch interactions for a smoother experience on both desktop and mobile devices.
  * Prevented background page scrolling when the address form modal is open.

* **Refactor**
  * Simplified how address coordinates are sent from the frontend, now using arrays instead of formatted strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->